### PR TITLE
added support for specifying core to port mapping

### DIFF
--- a/src/pktgen.h
+++ b/src/pktgen.h
@@ -13,6 +13,7 @@
 #include <math.h>
 #include <signal.h>
 #include <semaphore.h>
+#include <stdbool.h>
 
 /* start demo stuff */
 #include <errno.h>
@@ -25,6 +26,7 @@
 #include <sys/mman.h>
 #include <fcntl.h>
 #include <sys/wait.h>
+
 
 #include "protobufs/job.pb-c.h"
 #include "protobufs/status.pb-c.h"


### PR DESCRIPTION
You can now pass a core-port mapping at the commandline like this:

./pktgen LISTEN_PORT [CORE_TO_PORT_MAPPING]

CORE_TO_PORT_MAPPING is in the form 1.0 2.1 3.2 where core 1 handles port 0, core 2 handles port 1, etc. I strictly enforce that the core to port mapping is one to one.
